### PR TITLE
Add Event#getListeners

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,9 @@
 /* ----------------------------------------------------------- */
 
 const rules = {
+  '@typescript-eslint/no-unsafe-assignment': 'off',
+  '@typescript-eslint/no-unsafe-return': 'off',
+  '@typescript-eslint/explicit-module-boundary-types': 'off',
   '@typescript-eslint/camelcase': 'off',
   '@typescript-eslint/explicit-function-return-type': 'off',
   '@typescript-eslint/member-delimiter-style': [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,20 @@ project adheres to
 
 ## [Unreleased]
 
-- This repo will be migrating to a new organization: `@extend-chrome`
-- The runtime argument checks will be removed, as they can be inaccurate
+## [**0.6.0**] - 2020-07-27
+
+### Added
+
+- Events now have the method `getListeners`, which returns a
+  shallow copy of the internal listeners set
+
+### Changed
+
+- This repo was migrated to a new organization: `@extend-chrome`
+
+### Removed
+
+- The runtime argument type checks were removed
 
 ## [**0.5.3**] - 2020-05-29
 

--- a/src/add-elements.ts
+++ b/src/add-elements.ts
@@ -35,24 +35,24 @@ export const addEvent = (
       )
     }
 
-    const types = [
-      'boolean',
-      'number',
-      'string',
-      'function',
-      'object',
-    ]
-    args.forEach((arg, i) => {
-      const param = parameters[i]
-      if (
-        types.includes(param.type) &&
-        typeof arg !== param.type
-      ) {
-        throw new TypeError(
-          `Invalid argument for ${name}: (${param.name}) should be type "${param.type}"`,
-        )
-      }
-    })
+    // const types = [
+    //   'boolean',
+    //   'number',
+    //   'string',
+    //   'function',
+    //   'object',
+    // ]
+    // args.forEach((arg, i) => {
+    //   const param = parameters[i]
+    //   if (
+    //     types.includes(param.type) &&
+    //     typeof arg !== param.type
+    //   ) {
+    //     throw new TypeError(
+    //       `Invalid argument for ${name}: (${param.name}) should be type "${param.type}"`,
+    //     )
+    //   }
+    // })
 
     return args
   })

--- a/src/create-event.test.ts
+++ b/src/create-event.test.ts
@@ -18,15 +18,30 @@ describe('CallableEvent', () => {
     expect(spy).not.toBeCalled()
   })
 
+  test('getListeners', () => {
+    const selector = (x: any) => [x]
+    const event = createEvent(selector)
+    const spy = jest.fn()
+
+    event.addListener(spy)
+
+    const set = event.getListeners()
+
+    expect(set.size).toBe(1)
+    expect(set.has(spy)).toBe(true)
+
+    expect(spy).not.toBeCalled()
+  })
+
   test('hasListeners', () => {
     const selector = (x: any) => [x]
     const event = createEvent(selector)
     const spy = jest.fn()
 
     expect(event.hasListeners()).toBe(false)
-    
+
     event.addListener(spy)
-    
+
     expect(event.hasListeners()).toBe(true)
 
     expect(spy).not.toBeCalled()
@@ -48,8 +63,6 @@ describe('CallableEvent', () => {
 
     expect(spy1).not.toBeCalled()
   })
-
-  
 
   test('removeListener 1', () => {
     const selector = (x: any) => [x]

--- a/src/create-event.ts
+++ b/src/create-event.ts
@@ -49,6 +49,11 @@ type Callable<
   clearListeners(): void
 
   /**
+   * Get the listener Set
+   */
+  getListeners(): Set<C>
+
+  /**
    * Returns CallableEvent without callListeners
    */
   toEvent(): CoreEvent<C>
@@ -83,7 +88,7 @@ export const createEvent = <C extends EventCallback>(
  */
 export function createSetEvent<
   C extends EventCallback,
-  R extends MonotypeEventSelector<C> | EventSelector<C>
+  R extends EventSelector<C> | MonotypeEventSelector<C>
 >(selector: R): CallableEvent<C, R> {
   const _cbs = new Set<C>()
 
@@ -93,6 +98,7 @@ export function createSetEvent<
     hasListeners,
     callListeners,
     clearListeners,
+    getListeners,
     removeListener,
     toEvent() {
       return {
@@ -114,6 +120,8 @@ export function createSetEvent<
     return _cbs.size > 0
   }
   function callListeners(...args: Parameters<R>) {
+    // eslint-disable-next-line
+    // @ts-ignore
     const cbArgs = selector(...args)
 
     if (cbArgs) {
@@ -127,6 +135,9 @@ export function createSetEvent<
   }
   function clearListeners() {
     _cbs.clear()
+  }
+  function getListeners() {
+    return new Set(_cbs.values())
   }
 }
 
@@ -143,7 +154,7 @@ export function createSetEvent<
  */
 export function createMapEvent<
   C extends EventCallback,
-  E extends MonotypeEventSelector<C> | EventSelector<C>,
+  E extends EventSelector<C> | MonotypeEventSelector<C>,
   O extends OptionsSelector
 >(eventSelector: E, optionsSelector?: O): CallableEvent<C, E> {
   const _cbs: Map<C, any[]> = new Map()
@@ -154,6 +165,7 @@ export function createMapEvent<
     hasListeners,
     callListeners,
     clearListeners,
+    getListeners,
     removeListener,
     toEvent() {
       return {
@@ -181,6 +193,8 @@ export function createMapEvent<
   }
   function callListeners(...args: any[]) {
     _cbs.forEach((options, cb) => {
+      // eslint-disable-next-line
+      // @ts-ignore
       const cbArgs = eventSelector(...options, ...args)
 
       if (cbArgs) {
@@ -193,5 +207,8 @@ export function createMapEvent<
   }
   function clearListeners() {
     _cbs.clear()
+  }
+  function getListeners() {
+    return new Set(_cbs.keys())
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -46,6 +46,7 @@ test('get: event', () => {
     addListener: expect.any(Function),
     callListeners: expect.any(Function),
     clearListeners: expect.any(Function),
+    getListeners: expect.any(Function),
     hasListener: expect.any(Function),
     hasListeners: expect.any(Function),
     removeListener: expect.any(Function),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -109,6 +109,8 @@ test('deleteProperty: lastError', () => {
 })
 
 test('deleteProperty: delete namespace', () => {
+  // eslint-disable-next-line
+  // @ts-ignore
   delete chrome.alarms
 
   expect('alarms' in chrome).toBe(false)


### PR DESCRIPTION
This PR adds a method to get a shallow copy of the internal listeners Set. Changes to this Set will not modify the internal set, but if fine-grained assertions are required, or if you've done something crazy like wrapping the Chrome API Event objects, this feature will provide some relief.

Also, there was a runtime type check during calls to `Event#callListeners`, which was not tested and was sometimes wrong. This has been removed.