### PR TITLE
bump jest peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "typescript": "^3.9.3"
   },
   "peerDependencies": {
-    "jest": "^24.9.0"
+    "jest": "^26.0.1"
   }
 }


### PR DESCRIPTION
Community guidelines:

- [ x] I have read and understand the
      [contributing guidelines](https://github.com/extend-chrome/.github/blob/master/.github/CONTRIBUTING.md)
      and
      [code of conduct](https://github.com/extend-chrome/.github/blob/master/.github/CODE_OF_CONDUCT.md)

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x ] no

### Description

This package relies on conflicting versions of jest between its devDependencies (v26) and peerDependencies (v24). Since npm 7, peer dependencies that conflict will now throw an error when you try to install the package. I'm not sure but I think it was accidentally downgraded in this commit https://github.com/extend-chrome/jest-chrome/commit/34602dd4e9850fcf2a67de592052e4a28df553b1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L79.

To reproduce the error, run:
```
  npm install jest@26 jest-chrome
```
Error:
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: test@1.0.0
npm ERR! Found: jest@26.6.3
npm ERR! node_modules/jest
npm ERR!   jest@"^26.6.3" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer jest@"^24.9.0" from jest-chrome@0.7.0
npm ERR! node_modules/jest-chrome
npm ERR!   jest-chrome@"*" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```
